### PR TITLE
代入式を実装してみた。forマクロが書けるようになった

### DIFF
--- a/ast/modify.go
+++ b/ast/modify.go
@@ -63,6 +63,12 @@ func Modify(node Node, modifier ModifyFunc) Node {
 		}
 
 		node.Pairs = newPairs
+	case *CallExpression:
+		node.Function, _ = Modify(node.Function, modifier).(Expression)
+
+		for i := range node.Arguments {
+			node.Arguments[i], _ = Modify(node.Arguments[i], modifier).(Expression)
+		}
 	}
 
 	return modifier(node)

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -162,28 +162,37 @@ func evalHashLiteral(hashLiteral *ast.HashLiteral, env *object.Environment) obje
 	pairs := make(map[object.HashKey]object.HashPair)
 
 	for keyNode, valueNode := range hashLiteral.Pairs {
-		key := Eval(keyNode, env)
-		if isError(key) {
-			return key
+		err := setHashPair(pairs, keyNode, valueNode, env)
+		if isError(err) {
+			return err
 		}
-
-		// keyがおかしいなら、valueを評価する前に処理したほうが良いよね
-		hashableObj, ok := key.(object.Hashable)
-		if !ok {
-			return newError("unhashable type: %s", key.Type())
-		}
-
-		value := Eval(valueNode, env)
-		if isError(value) {
-			return value
-		}
-
-		hashed := hashableObj.HashKey()
-
-		pairs[hashed] = object.HashPair{Key: key, Value: value}
 	}
 
 	return &object.Hash{Pairs: pairs}
+}
+
+func setHashPair(pairs map[object.HashKey]object.HashPair, keyNode, valueNode ast.Node, env *object.Environment) object.Object {
+	key := Eval(keyNode, env)
+	if isError(key) {
+		return key
+	}
+
+	// keyがおかしいなら、valueを評価する前に処理したほうが良いよね
+	hashableObj, ok := key.(object.Hashable)
+	if !ok {
+		return newError("unhashable type: %s", key.Type())
+	}
+
+	value := Eval(valueNode, env)
+	if isError(value) {
+		return value
+	}
+
+	hashed := hashableObj.HashKey()
+
+	pairs[hashed] = object.HashPair{Key: key, Value: value}
+
+	return value
 }
 
 func evalIndexExpression(left, index object.Object) object.Object {
@@ -365,8 +374,23 @@ func evalAssignExpression(leftExpr, rightExpr ast.Expression, env *object.Enviro
 
 		storedEnv.Set(name, right)
 		return right
+	case *ast.IndexExpression:
+		assignSubject := Eval(left.Left, env)
+		if isError(assignSubject) {
+			return assignSubject
+		}
+
+		hashObj, ok := assignSubject.(*object.Hash)
+		if !ok {
+			return newError("updating %s is not supported", assignSubject.Type())
+		}
+
+		right := setHashPair(hashObj.Pairs, left.Index, rightExpr, env)
+
+		return right
 	default:
 		return newError("illegal assignment subject: %T", leftExpr)
+
 	}
 }
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -314,6 +314,11 @@ func TestErrorHandling(t *testing.T) {
 
 		//
 		{`{"name": "Monkey"}[fn(x) { x }];`, "unhashable type: FUNCTION"},
+
+		// 代入式
+		{`foobar = 1;`, "identifier not found: foobar"},
+		{`1 = "foobar";`, "illegal assignment subject: *ast.IntegerLiteral"},
+		{`["foobar"] = 1;`, "illegal assignment subject: *ast.ArrayLiteral"},
 	}
 
 	for _, tt := range tests {
@@ -830,4 +835,22 @@ func TestQuoteUnquote(t *testing.T) {
 		})
 	}
 
+}
+
+func TestAssignExpressions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int64
+	}{
+		{"let a = 5; a = a + 2; a;", 7},
+		{"let a = 5; (fn(){ a = a + 2; })(); a;", 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			evaluated := testEval(tt.input)
+
+			testIntegerObject(t, evaluated, tt.expected)
+		})
+	}
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -319,6 +319,7 @@ func TestErrorHandling(t *testing.T) {
 		{`foobar = 1;`, "identifier not found: foobar"},
 		{`1 = "foobar";`, "illegal assignment subject: *ast.IntegerLiteral"},
 		{`["foobar"] = 1;`, "illegal assignment subject: *ast.ArrayLiteral"},
+		{`let arr = []; arr[0] = 1;`, "updating ARRAY is not supported"},
 	}
 
 	for _, tt := range tests {
@@ -844,6 +845,7 @@ func TestAssignExpressions(t *testing.T) {
 	}{
 		{"let a = 5; a = a + 2; a;", 7},
 		{"let a = 5; (fn(){ a = a + 2; })(); a;", 7},
+		{`let a = {}; a["key"] = 5; a["key"];`, 5},
 	}
 
 	for _, tt := range tests {

--- a/evaluator/macro_expantion_test.go
+++ b/evaluator/macro_expantion_test.go
@@ -111,6 +111,39 @@ func TestExpandMacros(t *testing.T) {
                  `,
 			`if (!(10 > 5)) { puts("not greater") } else { puts("yep greater") }`,
 		},
+		{
+			`
+				let for = macro(init, cond, update, body) {
+					quote((fn(){
+				 		unquote(init);
+						let loop = fn() {
+							if (unquote(cond)) {
+								unquote(body);
+								unquote(update);
+								loop();
+							}
+						};
+						loop();
+					})())
+				};
+				for(if(true){ let i = 0; }, i < 10, i = i + 1, puts(i))
+			`,
+			`
+				(fn(){
+					if(true){
+						let i = 0;
+					}
+					let loop = fn() {
+						if(i < 10) {
+							puts(i);
+							i = i + 1;
+							loop();
+						};
+					};
+					loop();
+				})()
+			`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/object/environment.go
+++ b/object/environment.go
@@ -36,3 +36,17 @@ func (e *Environment) Set(name string, val Object) Object {
 
 	return val
 }
+
+func (e *Environment) GetStoredEnv(name string) *Environment {
+	_, ok := e.store[name]
+
+	if ok {
+		return e
+	}
+
+	if e.outer != nil {
+		return e.outer.GetStoredEnv(name)
+	}
+
+	return nil
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -24,6 +24,9 @@ var precedences = map[token.Type]int{
 	token.EQ:     EQUALS,
 	token.NOT_EQ: EQUALS,
 
+	// 代入式の場合どの値が正しいのかは知らない。適当に決めた
+	token.ASSIGN: EQUALS,
+
 	token.LT: LESSGREATER,
 	token.GT: LESSGREATER,
 
@@ -137,6 +140,9 @@ func New(l *lexer.Lexer) *Parser {
 	// myArray[0]
 	// `[` を 中置演算式におけるOperatorだと思うってこと！
 	p.registerInfix(token.LBRACKET, p.parseIndexExpression)
+
+	// 代入式
+	p.registerInfix(token.ASSIGN, p.parseInfixExpression)
 
 	return &p
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -266,6 +266,11 @@ func TestParsingInfixExpressions(t *testing.T) {
 
 		// BooleanLiteral系
 		{"true == true", true, "==", true},
+
+		// 代入式
+		// 合法だけど評価器的にはエラー
+		// 想定してるのは `x = 1` とか `hash["key"] = value` とか。
+		{"3 = 4", 3, "=", 4},
 	}
 
 	for _, tt := range infixTests {


### PR DESCRIPTION
本当は再代入は式じゃなくて文として扱いたい派だけど、一回その方針でParserに手を入れようとした時に結構な大工事が必要な気配がして諦めました。

あと `let a = []; a[10] = 1` のケースはどういう結果になるべきか分からなかったので実装しなかった